### PR TITLE
Replace DOCS_NEXT_TOKEN_NEW with DOCS_NEXT_TOKEN

### DIFF
--- a/.github/workflows/build-publish-staging.yaml
+++ b/.github/workflows/build-publish-staging.yaml
@@ -113,7 +113,7 @@ jobs:
           uses: actions/checkout@v4
           with: 
             repository: "${{ vars.DOCS_NEXT_CHARTS_ORG }}/${{ vars.DOCS_NEXT_CHARTS_REPO }}"
-            token: ${{ secrets.DOCS_NEXT_TOKEN_NEW }}
+            token: ${{ secrets.DOCS_NEXT_TOKEN }}
         - name: Commit Changes
           env:
             image: ${{ vars.REGISTRY }}/${{ vars.REGISTRY_ORG }}/${{ vars.IMG_NAME }}
@@ -130,5 +130,5 @@ jobs:
             remote_pr_branch: 'release/staging-${{ needs.build-preview.outputs.image_version }}'
           with:
             title: ${{ env.remote_pr_branch }}
-            token: ${{ secrets.DOCS_NEXT_TOKEN_NEW }}
+            token: ${{ secrets.DOCS_NEXT_TOKEN }}
             branch: ${{ env.remote_pr_branch }}


### PR DESCRIPTION
Updated the token used for checking out the charts repository and committing changes.